### PR TITLE
minios: fixing packet deallocation with lwip (issue #40)

### DIFF
--- a/elements/minios/fromdevice.cc
+++ b/elements/minios/fromdevice.cc
@@ -85,7 +85,28 @@ FromDevice::initialize(ErrorHandler *errh)
 	if (!_dev)
 		return errh->error("Unable to initialize netfront for device %d (%s)", _vifid, nodename);
 
-	netfront_set_rx_handler(_dev, FromDevice::rx_handler, (void*)this);
+#ifdef CONFIG_NETMAP
+	char* msg = NULL;
+	char* backend = NULL;
+	char path[256];
+
+	/* Read the backend path */
+	snprintf(path, sizeof(path), "%s/backend", nodename);
+	msg = xenbus_read(XBT_NIL, path, &backend);
+	free(msg);
+
+	if (backend == NULL)
+		return errh->error("Invalid backend");
+
+	/* Check if it's using netmap */
+	snprintf(path, sizeof(path), "%s/feature-netmap", backend);
+	free(backend);
+
+	if (xenbus_read_integer(path) > 0)
+		netfront_set_rx_handler(_dev, FromDevice::rx_handler, (void*)this);
+	else
+#endif
+	netfront_set_rx_pbuf_handler(_dev, FromDevice::pbuf_rx_handler, (void*)this);
 
 	ScheduleInfo::initialize_task(this, &_task, errh);
 
@@ -123,6 +144,20 @@ FromDevice::rx_handler(unsigned char* data, int len, void* e)
 {
 	Packet* p = Packet::make(data, len, FromDevice::pkt_destructor);
 	((FromDevice*) e)->_deque.push_back(p);
+}
+
+void
+FromDevice::pbuf_rx_handler(struct pbuf* pbuf_p, void* e)
+{
+	Packet* p = Packet::make((unsigned char*) pbuf_p->payload, pbuf_p->len, FromDevice::pbuf_pkt_destructor, pbuf_p);
+	((FromDevice*) e)->_deque.push_back(p);
+}
+
+void
+FromDevice::pbuf_pkt_destructor(unsigned char* data, long unsigned int lenght, void* arg)
+{
+	struct pbuf* pbuf_p = (struct pbuf*) arg;
+	pbuf_free(pbuf_p);
 }
 
 void

--- a/elements/minios/fromdevice.hh
+++ b/elements/minios/fromdevice.hh
@@ -119,6 +119,9 @@ private:
     static void rx_handler(unsigned char* data, int len, void* e);
     static void pkt_destructor(unsigned char* data, long unsigned int lenght, void* arg) {};
 
+    static void pbuf_rx_handler(struct pbuf* p, void* e);
+    static void pbuf_pkt_destructor(unsigned char* data, long unsigned int lenght, void* arg);
+
     static String read_handler(Element* e, void *thunk);
     static int reset_counts(const String &, Element *e, void *, ErrorHandler *);
 };


### PR DESCRIPTION
When a network interface is used without netmap, the lwip packet buffers do not get deallocated and the network driver stops receiving new packets after it runs out of buffer memory. The current fix registers a new handler which sets the packet destructor on network interfaces that do not use netmap.